### PR TITLE
Colorspacefix

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,7 +8,7 @@
 	<target name="compile">
 		<mkdir dir="target/classes"/>
 		<!-- nowarn is set to avoid hearing about all the "enum" variables. -->
-		<javac source="1.3" target="1.7" destdir="target/classes" srcdir="src/main/java" nowarn="true"/>
+		<javac source="1.3" target="1.7" destdir="target/classes" srcdir="src/main/java" nowarn="true" debug="true"/>
 	</target>
 
 	<target name="jar" depends="compile">

--- a/src/main/java/ucar/jpeg/colorspace/ColorSpace.java
+++ b/src/main/java/ucar/jpeg/colorspace/ColorSpace.java
@@ -8,6 +8,7 @@
 
 package ucar.jpeg.colorspace;
 
+import java.util.*;
 import java.io.IOException;
 import ucar.jpeg.jj2000.j2k.fileformat.FileFormatBoxes;
 import ucar.jpeg.jj2000.j2k.util.ParameterList;
@@ -52,6 +53,7 @@ public class ColorSpace {
     private ColorSpecificationBox csbox = null;
     private ChannelDefinitionBox  cdbox = null;
     private ImageHeaderBox        ihbox = null;
+    private List                  csboxes = null;
 
     /** Input image */
     private RandomAccessIO in=null;
@@ -152,6 +154,10 @@ public class ColorSpace {
                 break;
             case FileFormatBoxes.COLOUR_SPECIFICATION_BOX:
                 csbox = new ColorSpecificationBox (in,boxStart);
+                if (csboxes == null) {
+                    csboxes = new ArrayList();
+                }
+                csboxes.add(csbox);
                 break;
             case FileFormatBoxes.CHANNEL_DEFINITION_BOX:
                 cdbox = new ChannelDefinitionBox (in,boxStart);
@@ -192,6 +198,11 @@ public class ColorSpace {
     /** Return number of channels in the palette. */
     public  /*final*/ PaletteBox getPaletteBox() {
         return pbox; }
+
+    public List getColorSpecificationBoxes() {
+        return csboxes == null ? Collections.emptyList() : csboxes;
+    }
+
 
     /** Return number of channels in the palette. */
     public int getPaletteChannels() {

--- a/src/main/java/ucar/jpeg/colorspace/boxes/ColorSpecificationBox.java
+++ b/src/main/java/ucar/jpeg/colorspace/boxes/ColorSpecificationBox.java
@@ -27,6 +27,7 @@ public final class ColorSpecificationBox extends JP2Box {
     private ColorSpace.MethodEnum method     = null;
     private ColorSpace.CSEnum colorSpace = null;
     private byte[] iccProfile = null;
+    private int cs, rawmethod, approxAccuracy;
 
     /**
      * Construct a ColorSpecificationBox from an input image.
@@ -45,10 +46,11 @@ public final class ColorSpecificationBox extends JP2Box {
         byte[] boxHeader = new byte[256];
         in.seek (dataStart);
         in.readFully(boxHeader,0,11);
-        switch (boxHeader[0]) {
+        rawmethod = boxHeader[0];
+        approxAccuracy = boxHeader[2];
+        switch (rawmethod) {
         case 1:    
-            method = ColorSpace.ENUMERATED;
-            int cs = ICCProfile.getInt(boxHeader,3);
+            cs = ICCProfile.getInt(boxHeader,3);
             switch (cs) {
             case 16:
                 colorSpace = ColorSpace.sRGB;
@@ -69,24 +71,47 @@ public final class ColorSpecificationBox extends JP2Box {
             break;  // from switch (boxHeader[0])...
         case 2:
             method = ColorSpace.ICC_PROFILED;
+            cs = -1;
             int size =  ICCProfile.getInt (boxHeader, 3);
             iccProfile = new byte [size];
             in.seek(dataStart+3);
             in.readFully (iccProfile,0,size); 
             break;  // from switch (boxHeader[0])...
         default:
-            throw new ColorSpaceException ("Bad specification method ("+
-					   boxHeader[0]+") in " + this);
+            throw new ColorSpaceException ("Bad specification method ("+ boxHeader[0]+") in " + this);
         }
     }
 
     /* Return an enumeration for the colorspace method. */
     public ColorSpace.MethodEnum getMethod () {
-        return method; }
+        return method;
+    }
 
     /* Return an enumeration for the ucar.jpeg.colorspace. */
     public ColorSpace.CSEnum getColorSpace () {
-        return colorSpace; }
+        return colorSpace;
+    }
+
+    /**
+     * Return the value of the Method field
+     */
+    public int getRawMethod () {
+        return rawmethod;
+    }
+
+    /**
+     * Return the value of the approxAccuracy field
+     */
+    public int getRawApproximationAccuracy () {
+        return approxAccuracy;
+    }
+
+    /**
+     * Return the value of the ColorSpace field
+     */
+    public int getRawColorSpace () {
+        return cs;
+    }
 
     /* Return a String representation of the ucar.jpeg.colorspace. */
     public String getColorSpaceString () {

--- a/src/main/java/ucar/jpeg/jj2000/j2k/codestream/reader/FileBitstreamReaderAgent.java
+++ b/src/main/java/ucar/jpeg/jj2000/j2k/codestream/reader/FileBitstreamReaderAgent.java
@@ -654,6 +654,11 @@ public class FileBitstreamReaderAgent extends BitstreamReaderAgent
         }
 	// TNsot
 	int nrOfTileParts = in.read();
+        // SPEC DEVIATION: Spec declares TNsot as "Number of tile-parts of a tile in the codestream",
+        // but many images seem to treat this value as "Maximum number of tile parts", i.e. one more.
+        // Reading less tiles than expected is handled, so we can safely increase this value by
+        // one for images.
+        nrOfTileParts++;
         ms.tnsot = nrOfTileParts;
         hi.sot.put("t"+tile+"_tp"+tilePart,ms);
         if(nrOfTileParts==0) { // The number of tile-part is not specified in


### PR DESCRIPTION
Hi UCAR team

Surprise, I bet you thought no-one would be foolish enough to attempt changes to this antique codebase. But, there is a long-standing bug in image compression which I have finally isolated, in FileBitstreamReaderAgent. This was a regression from the 5.1 release.

I've also added the bare minimum of methods required to retrieve information on colorspaces, again functionality which was present in 5.1 but removed in 5.2.