### PR TITLE
Get project to build with Ant 1.10

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,7 +8,9 @@
 	<target name="compile">
 		<mkdir dir="target/classes"/>
 		<!-- nowarn is set to avoid hearing about all the "enum" variables. -->
-		<javac source="1.3" target="1.7" destdir="target/classes" srcdir="src/main/java" nowarn="true" debug="true"/>
+		<javac source="1.8" target="1.8" destdir="target/classes" srcdir="src/main/java" nowarn="true" debug="true">
+			<compilerarg line="-encoding ISO-8859-1"/>
+		</javac>
 	</target>
 
 	<target name="jar" depends="compile">


### PR DESCRIPTION
The project does not build from a fresh clone when using Ant 1.10, giving the following error:
```
Buildfile: /home/spidru/Documents/jj2000/build.xml

compile:
    [mkdir] Created dir: /home/spidru/Documents/jj2000/target/classes
    [javac] /home/spidru/Documents/jj2000/build.xml:11: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 224 source files to /home/spidru/Documents/jj2000/target/classes
    [javac] error: Source option 1.3 is no longer supported. Use 6 or later.

BUILD FAILED
/home/spidru/Documents/jj2000/build.xml:11: Compile failed; see the compiler error output for details.
```
With the proposed changes, the project builds again with Ant 1.10:
```
Buildfile: /home/spidru/Documents/jj2000/build.xml

compile:
    [mkdir] Created dir: /home/spidru/Documents/jj2000/target/classes
    [javac] /home/spidru/Documents/jj2000/build.xml:11: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
    [javac] Compiling 224 source files to /home/spidru/Documents/jj2000/target/classes
    [javac] Note: Some input files use or override a deprecated API.
    [javac] Note: Recompile with -Xlint:deprecation for details.
    [javac] Note: Some input files use unchecked or unsafe operations.
    [javac] Note: Recompile with -Xlint:unchecked for details.

jar:
      [jar] Building jar: /home/spidru/Documents/jj2000/target/jj2000-5.2-SNAPSHOT.jar

BUILD SUCCESSFUL
Total time: 2 seconds